### PR TITLE
Allow devices with spaces in their names

### DIFF
--- a/lib/characteristics.js
+++ b/lib/characteristics.js
@@ -11,7 +11,7 @@ exports.getPowerState = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " powerstate" + " get";
+      cmd += " '" + that.name + "' powerstate" + " get";
     }
     // Execute command to get PowerState
     exec(cmd, function (error, stdout, stderr) {
@@ -34,7 +34,7 @@ exports.setPowerState = function(state, callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " powerstate " + "set " + state;
+      cmd += " '" + that.name + "' powerstate " + "set " + state;
     }  
     // Execute command to set PowerState
     exec(cmd, function (error, stdout, stderr) {

--- a/lib/characteristics.js
+++ b/lib/characteristics.js
@@ -61,7 +61,7 @@ exports.getBrightness = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " brightness" + " get";
+      cmd += " '" + that.name + "' brightness" + " get";
     }
     // Execute command to get brightness
     exec(cmd, function (error, stdout, stderr) {
@@ -84,7 +84,7 @@ exports.setBrightness = function(value, callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " brightness " + "set " + value;
+      cmd += " '" + that.name + "' brightness " + "set " + value;
     }  
     // Execute command to set Brightness
     exec(cmd, function (error, stdout, stderr) {
@@ -111,7 +111,7 @@ exports.getSaturation = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " saturation" + " get";
+      cmd += " '" + that.name + "' saturation" + " get";
     }
     // Execute command to get Saturation
     exec(cmd, function (error, stdout, stderr) {
@@ -134,7 +134,7 @@ exports.setSaturation = function(value, callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " saturation " + "set " + value;
+      cmd += " '" + that.name + "' saturation " + "set " + value;
     }  
     // Execute command to set Saturation
     exec(cmd, function (error, stdout, stderr) {
@@ -161,7 +161,7 @@ exports.getHue = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " hue" + " get";
+      cmd += " '" + that.name + "' hue" + " get";
     }
     // Execute command to get Hue
     exec(cmd, function (error, stdout, stderr) {
@@ -184,7 +184,7 @@ exports.setHue = function(value, callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " hue " + "set " + value;
+      cmd += " '" + that.name + "' hue " + "set " + value;
     }  
     // Execute command to set Hue
     exec(cmd, function (error, stdout, stderr) {
@@ -211,7 +211,7 @@ exports.getColorTemperature = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " colortemperature" + " get";
+      cmd += " '" + that.name + "' colortemperature" + " get";
     }
     // Execute command to get Color Temperature
     exec(cmd, function (error, stdout, stderr) {
@@ -234,7 +234,7 @@ exports.setColorTemperature = function(value, callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " colortemperature " + "set " + value;
+      cmd += " '" + that.name + "' colortemperature " + "set " + value;
     }  
     // Execute command to set Color Temperature
     exec(cmd, function (error, stdout, stderr) {
@@ -261,7 +261,7 @@ exports.getOutletInUse = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " outletinuse" + " get";
+      cmd += " '" + that.name + "' outletinuse" + " get";
     }
     // Execute command to get Outlet in use
     exec(cmd, function (error, stdout, stderr) {
@@ -289,7 +289,7 @@ exports.getMute = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " mute" + " get";
+      cmd += " '" + that.name + "' mute" + " get";
     }
     // Execute command to get mute
     exec(cmd, function (error, stdout, stderr) {
@@ -312,7 +312,7 @@ exports.setMute = function(state, callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " mute " + "set " + state;
+      cmd += " '" + that.name + "' mute " + "set " + state;
     }  
     // Execute command to set Mute
     exec(cmd, function (error, stdout, stderr) {
@@ -339,7 +339,7 @@ exports.getVolume = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " volume" + " get";
+      cmd += " '" + that.name + "' volume" + " get";
     }
     // Execute command to get the Volume
     exec(cmd, function (error, stdout, stderr) {
@@ -362,7 +362,7 @@ exports.setVolume = function(value, callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " volume " + "set " + value;
+      cmd += " '" + that.name + "' volume " + "set " + value;
     }  
     // Execute command to set volume
     exec(cmd, function (error, stdout, stderr) {
@@ -389,7 +389,7 @@ exports.getCurrentPosition = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " currentposition" + " get";
+      cmd += " '" + that.name + "' currentposition" + " get";
     }
     // Execute command to get the Current Position
     exec(cmd, function (error, stdout, stderr) {
@@ -416,7 +416,7 @@ exports.getTargetPosition = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " targetposition" + " get";
+      cmd += " '" + that.name + "' targetposition" + " get";
     }
     // Execute command to get the Target Position
     exec(cmd, function (error, stdout, stderr) {
@@ -439,7 +439,7 @@ exports.setTargetPosition = function(value, callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " targetposition " + "set " + value;
+      cmd += " '" + that.name + "' targetposition " + "set " + value;
     }  
     // Execute command to set Target Position
     exec(cmd, function (error, stdout, stderr) {
@@ -466,7 +466,7 @@ exports.getPositionState = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " positionstate" + " get";
+      cmd += " '" + that.name + "' positionstate" + " get";
     }
     // Execute command to get the Position State
     exec(cmd, function (error, stdout, stderr) {
@@ -493,7 +493,7 @@ exports.setHoldPosition = function(state, callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " holdposition " + "set " + state;
+      cmd += " '" + that.name + "' holdposition " + "set " + state;
     }  
     // Execute command to set Hold position
     exec(cmd, function (error, stdout, stderr) {
@@ -519,7 +519,7 @@ exports.getTargetHorizontalTiltAngle = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " targethorizontaltiltangle" + " get";
+      cmd += " '" + that.name + "' targethorizontaltiltangle" + " get";
     }
     // Execute command to get the Target Horizontal Tilt Angle
     exec(cmd, function (error, stdout, stderr) {
@@ -542,7 +542,7 @@ exports.setTargetHorizontalTiltAngle = function(value, callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " targethorizontaltiltangle " + "set " + value;
+      cmd += " '" + that.name + "' targethorizontaltiltangle " + "set " + value;
     }  
     // Execute command to set Target Position
     exec(cmd, function (error, stdout, stderr) {
@@ -569,7 +569,7 @@ exports.getTargetVerticalTiltAngle = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " targetverticaltiltangle" + " get";
+      cmd += " '" + that.name + "' targetverticaltiltangle" + " get";
     }
     // Execute command to get the Target Vertical Tilt Angle
     exec(cmd, function (error, stdout, stderr) {
@@ -592,7 +592,7 @@ exports.setTargetVerticalTiltAngle = function(value, callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " targetverticaltiltangle " + "set " + value;
+      cmd += " '" + that.name + "' targetverticaltiltangle " + "set " + value;
     }  
     // Execute command to set Target Position
     exec(cmd, function (error, stdout, stderr) {
@@ -619,7 +619,7 @@ exports.getCurrentHorizontalTiltAngle = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " currenthorizontaltiltangle" + " get";
+      cmd += " '" + that.name + "' currenthorizontaltiltangle" + " get";
     }
     // Execute command to get the Current Horizontal Tilt Angle
     exec(cmd, function (error, stdout, stderr) {
@@ -646,7 +646,7 @@ exports.getCurrentVerticalTiltAngle = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " currentverticaltiltangle" + " get";
+      cmd += " '" + that.name + "' currentverticaltiltangle" + " get";
     }
     // Execute command to get the Current Vertical Tilt Angle
     exec(cmd, function (error, stdout, stderr) {
@@ -673,7 +673,7 @@ exports.getObstructionDetected = function(callback) {
   
     // Add arguments
     if(!that.no_arg){
-      cmd += " " + that.name + " obstructiondetected" + " get";
+      cmd += " '" + that.name + "' obstructiondetected" + " get";
     }
     // Execute command to get Obstruction Detected
     exec(cmd, function (error, stdout, stderr) {


### PR DESCRIPTION
I haven't tested this because I can't find this corresponding file on my installation, but this *should* work.  I can run my script like this:

`./etekcity_control.sh 'game cube' powerstate set false`

and it works.  My log however shows that the script is being called with:

`./etekcity_control.sh game cube powerstate set false`

because $1 just has "game".