### PR TITLE
Validate accessory type

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function commanderCommand(log, commandConfig) {
   this.config = commandConfig;
   this.name = commandConfig.name;
   this.updaterate = commandConfig.updaterate || 5000;
-  this.type = commandConfig.type;
+  this.type = commandConfig.type.toLoweCase();
   this.cmd = commandConfig.cmd;
   this.no_arg = commandConfig.no_arg || false;
   this.custom = commandConfig.custom || false;
@@ -71,7 +71,7 @@ function commanderCommand(log, commandConfig) {
   this.settings.currenthorizontaltiltangle = commandConfig.currenthorizontaltiltangle || false;
   this.settings.currentverticaltiltangle = commandConfig.currentverticaltiltangle || false;
   this.settings.obstructiondetected = commandConfig.obstructiondetected || false;
-  //Custom (Are default for other but not for costum)
+  //Custom (Are default for other but not for custom)
   this.settings.powerstate = commandConfig.powerstate || false;
   this.settings.outletinuse = commandConfig.outletinuse || false;
   this.settings.mute = commandConfig.mute || false;

--- a/lib/services.js
+++ b/lib/services.js
@@ -49,6 +49,10 @@ module.exports.addService = function(that) {
             that.service = new Service.HumiditySensor(that.name);
             break;
         }
+        default: 
+        {
+            throw new Error("Unsupported accessory type: " + that.type);
+        }
     }
   }
 


### PR DESCRIPTION
This converts accessory type to lower case and throws an error if unsupported accessory type is specified in the configuration. I had to debug through the whole homebridge in order to understand what is going on because the error was quite subtle:

```
TypeError: Cannot read property 'UUID' of undefined
    at Accessory.addService (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/Accessory.js:149:35)
    at /usr/local/lib/node_modules/homebridge/lib/server.js:471:19
    at Array.forEach (<anonymous>)
    at Server._createAccessory (/usr/local/lib/node_modules/homebridge/lib/server.js:452:14)
    at Server.<anonymous> (/usr/local/lib/node_modules/homebridge/lib/server.js:413:32)
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/util/once.js:16:19
    at commanderPlatform.accessories (/usr/local/lib/node_modules/homebridge-commander/index.js:36:3)
    at Server._loadPlatformAccessories (/usr/local/lib/node_modules/homebridge/lib/server.js:403:20)
    at Server._loadPlatforms (/usr/local/lib/node_modules/homebridge/lib/server.js:341:16)
    at Server.run (/usr/local/lib/node_modules/homebridge/lib/server.js:90:36)
```

With this change homebridge will fail earlier and with a better error message.